### PR TITLE
Sample rate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 #### Setup
 
-```
+```php
 $app['qafoo.profiler.key'] = '{enter here your qafoo key}';
 $app['qafoo.profiler.sample_rate'] = 20; // value equals %
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 ```
 $app['qafoo.profiler.key'] = '{enter here your qafoo key}';
+$app['qafoo.profiler.sample_rate'] = 20; // value equals %
+
+// If you are in develop mode, this will ignore the sample rate and use 100% 
 $app['qafoo.profiler.development'] = true;
 
 $app->register(new \Easybib\Silex\Provider\QafooProfilerServiceProvider());

--- a/src/Provider/QafooProfilerServiceProvider.php
+++ b/src/Provider/QafooProfilerServiceProvider.php
@@ -18,7 +18,8 @@ class QafooProfilerServiceProvider implements ServiceProviderInterface
             Profiler::startDevelopment($app['qafoo.profiler.key']);
             Profiler::setBackend(new Profiler\CurlBackend());
         } else {
-            Profiler::start($app['qafoo.profiler.key']);
+            $sampleRate = isset($app['qafoo.profiler.sample_rate']) ? $app['qafoo.profiler.sample_rate'] : null;
+            Profiler::start($app['qafoo.profiler.key'], $sampleRate);
         }
     }
 


### PR DESCRIPTION
With commit https://github.com/QafooLabs/profiler/commit/1d6b05e1d4c7b8f856bd8f1a744cbd089d5b28e3 they removed the 20% default value for the sample rate and use now ini values for default values.

If value is not set than false => 0% of your request will be traced.