### PR TITLE
Option to blacklist (not track) certain routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,6 @@ List of options:
 
  * qafoo.profiler.key (required)
  * qafoo.profiler.sample_rate
+ * qafoo.profiler.route_blacklist
 
 The provider will setup the qafoo profiler as soon as the register method is called.

--- a/src/Provider/QafooProfilerServiceProvider.php
+++ b/src/Provider/QafooProfilerServiceProvider.php
@@ -72,6 +72,13 @@ class QafooProfilerServiceProvider implements ServiceProviderInterface
         }
 
         $actionName = $request->get('_route');
+
+        $blacklist = isset($app['qafoo.profiler.route_blacklist']) ? array_flip($app['qafoo.profiler.route_blacklist']) : [];
+        if (isset($blacklist[$actionName])) {
+            \Tideways\Profiler::ignoreTransaction();
+            return;
+        }
+
         if (strpos($actionName, '__') === 0) {
             $actionName = $request->get('_controller');
         }


### PR DESCRIPTION
Need a way to blacklist (i.e. not collect any traces) certain routes. For instance it makes no sense to collect data for all web-profiler calls.

````php
$app['qafoo.profiler.blacklist'] = [
    '_wdt',
];
````
