### PR TITLE
Avoid setting tideways key to null

### DIFF
--- a/src/Provider/QafooProfilerServiceProvider.php
+++ b/src/Provider/QafooProfilerServiceProvider.php
@@ -20,8 +20,11 @@ class QafooProfilerServiceProvider implements ServiceProviderInterface, Bootable
             return;
         }
 
-        $sampleRate = isset($app['qafoo.profiler.sample_rate']) ? $app['qafoo.profiler.sample_rate'] : null;
-        \Tideways\Profiler::start($app['qafoo.profiler.key'], $sampleRate);
+        // override key if specified, or attempt starting if tideways is not configured to autostart
+        if (isset($app['qafoo.profiler.key']) || \Tideways\Profiler::isStarted()) {
+            $sampleRate = isset($app['qafoo.profiler.sample_rate']) ? $app['qafoo.profiler.sample_rate'] : null;
+            \Tideways\Profiler::start($app['qafoo.profiler.key'], $sampleRate);
+        }
     }
 
     /**

--- a/src/Provider/QafooProfilerServiceProvider.php
+++ b/src/Provider/QafooProfilerServiceProvider.php
@@ -21,7 +21,7 @@ class QafooProfilerServiceProvider implements ServiceProviderInterface, Bootable
         }
 
         // override key if specified, or attempt starting if tideways is not configured to autostart
-        if (isset($app['qafoo.profiler.key']) || \Tideways\Profiler::isStarted()) {
+        if (isset($app['qafoo.profiler.key']) || !ini_get("tideways.auto_start")) {
             $sampleRate = isset($app['qafoo.profiler.sample_rate']) ? $app['qafoo.profiler.sample_rate'] : null;
             \Tideways\Profiler::start($app['qafoo.profiler.key'], $sampleRate);
         }


### PR DESCRIPTION
When tideways is configured via env vars and set to auto start, it shouldn't be overwritten here as it disables it